### PR TITLE
Fix up selector thingy

### DIFF
--- a/assets/plugin.js
+++ b/assets/plugin.js
@@ -25,7 +25,7 @@ require(['gitbook', 'jQuery'], function (gitbook, $) {
     $.each(versions, function(i, version) {
       var $option = $('<option>', {
         'selected': window.location.href.indexOf(version.value) !== -1,
-        'value': version.value+CurAddrNoAnchor,
+        'value': version.value,
         'text': version.text
       });
 
@@ -39,7 +39,9 @@ require(['gitbook', 'jQuery'], function (gitbook, $) {
             // Get actual version Object from array
       var version = filtered[0];
 
-      var filePath = window.location.href.replace(gitbook.state.bookRoot, '');
+      //var filePath = window.location.href.replace(gitbook.state.bookRoot, '');
+      var filePath = CurAddrNoAnchor;
+      version.includeFilepath=true; //This is otherwise undefined. Supposed to come from file but gets skipped.
       window.location.href = version.includeFilepath ? (version.value + filePath) : version.value;
     });
 


### PR DESCRIPTION
This fixes version selector *somewhat*.  The original plugin is a bit broken in that it doesn't get the file path properly (`version.includeFilepath` is skipped) . This fix makes things work for our configuration but is not a generic fix. 